### PR TITLE
More tests

### DIFF
--- a/src/lib.mo
+++ b/src/lib.mo
@@ -27,7 +27,7 @@ module {
 
     public var result : ?R = null;
 
-    var middle_result : ?S = null;
+    var midstate : ?S = null;
 
     public func release() {
       if (not lock) {
@@ -35,12 +35,12 @@ module {
       };
       lock := false;
       let ?(_, after) = methods else return;
-      let ?s = middle_result else Debug.trap("middle result expected");
+      let ?s = midstate else Debug.trap("middle result expected");
       result := after(s);
     };
 
     public func run(arg : T) : async () {
-      middle_result := Option.map<Methods<T, S, R>, S>(methods, func((pre, _)) = pre(arg));
+      midstate := Option.map<Methods<T, S, R>, S>(methods, func((pre, _)) = pre(arg));
       state := #running;
 
       var inc = limit;

--- a/test/mock.test.mo
+++ b/test/mock.test.mo
@@ -78,6 +78,7 @@ do {
 
   target.x := 5;
   target.get_.release(0);
+  await async {};
   target.x := 3;
   target.get_.release(1);
 

--- a/test/mock.test.mo
+++ b/test/mock.test.mo
@@ -78,7 +78,6 @@ do {
 
   target.x := 5;
   target.get_.release(0);
-  await async {};
   target.x := 3;
   target.get_.release(1);
 

--- a/test/mock.test.mo
+++ b/test/mock.test.mo
@@ -53,7 +53,7 @@ do {
   let r0 = await fut0;
   let r1 = await fut1;
 
-  Debug.print(debug_show (r0, r1));
+  // Debug.print(debug_show (r0, r1));
   assert r0 == 5 and r1 == 8;
 };
 
@@ -84,6 +84,6 @@ do {
   let r0 = await fut0;
   let r1 = await fut1;
 
-  Debug.print(debug_show (r0, r1));
+  // Debug.print(debug_show (r0, r1));
   assert r0 == 5 and r1 == 8;
 };

--- a/test/mock.test.mo
+++ b/test/mock.test.mo
@@ -29,25 +29,61 @@ class CodeToTest(targetAPI : TargetAPI) {
   };
 };
 
-// We are mocking the target with AsyncMethodTesters
-let target = object {
-  public let get_ = AsyncMethodTester.ReleaseAsyncMethodTester<Nat>(null);
-  public shared func get() : async Nat = async get_.call_result(await* get_.call());
+// Demo: ReleaseAsyncMethodTester
+do {
+  // We are mocking the target with AsyncMethodTesters
+  let target = object {
+    public let get_ = AsyncMethodTester.ReleaseAsyncMethodTester<Nat>(null);
+    public shared func get() : async Nat {
+      get_.call_result(await* get_.call());
+    };
+  };
+
+  // We are instantiating the code to test
+  let code = CodeToTest(target);
+
+  // Now the actual test runs
+  let fut0 = async await* code.fetch();
+  let fut1 = async await* code.fetch();
+  await async {};
+
+  target.get_.release(0, ?5);
+  target.get_.release(1, ?3);
+
+  let r0 = await fut0;
+  let r1 = await fut1;
+
+  Debug.print(debug_show (r0, r1));
+  assert r0 == 5 and r1 == 8;
 };
 
-// We are instantiating the code to test
-let code = CodeToTest(target);
+// Demo: CallAsyncMethodTester
+do {
+  // We are mocking the target with AsyncMethodTesters
+  let target = object {
+    public let get_ = AsyncMethodTester.CallAsyncMethodTester<(), Nat>(null);
+    public var x : Nat = 0;
+    public shared func get() : async Nat {
+      get_.call_result(await* get_.call((), func() = ?x));
+    };
+  };
 
-// Now the actual test runs
-let fut0 = async await* code.fetch();
-let fut1 = async await* code.fetch();
-await async {};
+  // We are instantiating the code to test
+  let code = CodeToTest(target);
 
-target.get_.release(0, ?5);
-target.get_.release(1, ?3);
+  // Now the actual test runs
+  let fut0 = async await* code.fetch();
+  let fut1 = async await* code.fetch();
+  await async {};
 
-let r0 = await fut0;
-let r1 = await fut1;
+  target.x := 5;
+  target.get_.release(0);
+  target.x := 3;
+  target.get_.release(1);
 
-Debug.print(debug_show (r0, r1));
-assert r0 == 5 and r1 == 8;
+  let r0 = await fut0;
+  let r1 = await fut1;
+
+  Debug.print(debug_show (r0, r1));
+  assert r0 == 5 and r1 == 8;
+};


### PR DESCRIPTION
Add test that shows timing problems with the release and `after` function mechanism.
Demonstrate a fix.
Now the behaviour between Call tester and Release tester is consistent.